### PR TITLE
Update example YAML to use arrays for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ steps:
 - label: ":arrow_double_up::load: Load SSM"
   command: "env | grep MySecret"
   plugins:
-    biltong/ssm#v0.1.0:
-      assume-role-arn: "arn:aws:iam::123456789012:role/RoleToAssume-1234567890"
-      ssmkey: "MySecret"
+    - biltong/ssm#v0.1.0:
+        assume-role-arn: "arn:aws:iam::123456789012:role/RoleToAssume-1234567890"
+        ssmkey: "MySecret"
 ```
 
 The resulting environment variable will be named 'MySecret'


### PR DESCRIPTION
Hi @biltong! 😊

Harriet from Buildkite here 👋🏻 We’ve [updated](https://buildkite.com/changelog/45-updated-syntax-for-using-plugins-in-your-pipeline-yaml) our recommended plugin syntax to use arrays instead of a map, to help ensure plugins are executed in the correct order with all agent versions.

This PR updates your readme example to be the new recommended syntax, and makes them pass the latest [plugin-linter](https://github.com/buildkite-plugins/buildkite-plugin-linter) checks.

Let me know if you have any questions! We’d love to get the readme updated so people use the new best-practice syntax.